### PR TITLE
feat: support auto-highlighting

### DIFF
--- a/example/src/App.svelte
+++ b/example/src/App.svelte
@@ -59,3 +59,7 @@
   }
   `}
 </pre>
+
+<pre data-language>{`body { color: red; }`}</pre>
+
+<pre data-language="auto">{`body { color: red; }`}</pre>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -4,7 +4,7 @@ interface Node {
   name: string;
   attributes: Array<{
     name: string;
-    value: [{ raw: string }];
+    value: true | [{ raw: string }];
   }>;
   children: [
     | undefined

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -1,5 +1,7 @@
 // Vitest Snapshot v1
 
+exports[`svelte-preprocess-highlight > auto-highlight 1`] = `"<pre><code class=\\"hljs\\">{@html \`<span class=\\"hljs-selector-tag\\">body</span> { <span class=\\"hljs-attribute\\">color</span>: red; }\`}</code></pre>"`;
+
 exports[`svelte-preprocess-highlight > invalid language 1`] = `"<pre data-language=\\"hypescript\\">{'hype'}</pre>"`;
 
 exports[`svelte-preprocess-highlight > multiple 1`] = `

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -70,6 +70,10 @@ describe("svelte-preprocess-highlight", () => {
   
   <Highlight language={typescript} {code} />\`}</pre>`;
 
+  const AUTO_HIGHLIGHT = `<pre data-language>{\`body { color: red; }\`}</pre>`;
+
+  const AUTO_HIGHLIGHT_EXPLICIT = `<pre data-language="auto">{\`body { color: red; }\`}</pre>`;
+
   test("filter – no file name", () => {
     expect(p("content", "")).toEqual(undefined);
   });
@@ -147,5 +151,10 @@ describe("svelte-preprocess-highlight", () => {
 
   test("svelte - multiline", () => {
     expect(p(SVELTE_MULTILINE)).toMatchSnapshot();
+  });
+
+  test("auto-highlight", () => {
+    expect(p(AUTO_HIGHLIGHT)).toMatchSnapshot();
+    expect(p(AUTO_HIGHLIGHT)).toEqual(p(AUTO_HIGHLIGHT_EXPLICIT));
   });
 });


### PR DESCRIPTION
This uses the `highlightAuto` API if no value is specified for the `data-highlight` attribute or if the value is "auto."

**Usage**

```svelte
<pre data-language>{`body { color: red; }`}</pre>
<!-- OR -->
<pre data-language="auto">{`body { color: red; }`}</pre>
```