### PR TITLE
fix: source map filename should use the source property

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -128,7 +128,7 @@ export const highlight: SveltePreprocessor<"markup", HighlightOptions> = (option
 
       return {
         code: s.toString(),
-        map: s.generateMap({ file: filename, includeContent: true }),
+        map: s.generateMap({ source: filename, includeContent: true }),
       };
     },
   };


### PR DESCRIPTION
The correct property for the original file name should be `source`, not `file`.